### PR TITLE
chore: migrate jdfalk/ refs to falkcorp/ org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   ci:
-    uses: jdfalk/ghcommon/.github/workflows/reusable-ci.yml@83352d45a93951d4e490a5c310e31858a52e29ce # main
+    uses: falkcorp/github-common/.github/workflows/reusable-ci.yml@83352d45a93951d4e490a5c310e31858a52e29ce # main
     with:
       go-version: "1.24"
       skip-protobuf: false # Need protobuf generation for Go SDK (from BSR)

--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -49,13 +49,13 @@ jobs:
 
       - name: Generate Go code from BSR
         run: |
-          echo "Generating Go code from buf.build/jdfalk/gcommon..."
+          echo "Generating Go code from buf.build/falkcorp/gcommon..."
           buf generate
 
       - name: Update go.mod module reference
         run: |
           # Ensure generated .pb.go files use the correct module path
-          find . -name "*.pb.go" -type f -exec sed -i 's|github.com/jdfalk/gcommon-go|github.com/jdfalk/gcommon|g' {} \;
+          find . -name "*.pb.go" -type f -exec sed -i 's|github.com/falkcorp/gcommon-go|github.com/falkcorp/gcommon|g' {} \;
 
       - name: Run go mod tidy
         run: go mod tidy
@@ -81,7 +81,7 @@ jobs:
           git add .
           git commit -m "feat(gen): regenerate Go code from BSR
 
-          Automatically regenerated Go code from buf.build/jdfalk/gcommon.
+          Automatically regenerated Go code from buf.build/falkcorp/gcommon.
 
           Generated from latest protocol buffer definitions."
           git push
@@ -96,4 +96,4 @@ jobs:
           else
             echo "ℹ️ No changes detected - generated code is up to date" >> $GITHUB_STEP_SUMMARY
           fi
-          echo "🔗 Source: buf.build/jdfalk/gcommon" >> $GITHUB_STEP_SUMMARY
+          echo "🔗 Source: buf.build/falkcorp/gcommon" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Go SDK for gcommon protocol buffers with generated Go bindings
 
 ## Overview
 
-This repository provides Go bindings for the [gcommon](https://github.com/jdfalk/gcommon) protocol buffer definitions via the [Buf Schema Registry](https://buf.build/jdfalk/gcommon). It includes all generated Go code and provides a stable Go module for consuming gcommon services.
+This repository provides Go bindings for the [gcommon](https://github.com/falkcorp/gcommon) protocol buffer definitions via the [Buf Schema Registry](https://buf.build/falkcorp/gcommon). It includes all generated Go code and provides a stable Go module for consuming gcommon services.
 
 ## Features
 
-- **BSR Integration**: Uses buf.build/jdfalk/gcommon for protocol buffer definitions
+- **BSR Integration**: Uses buf.build/falkcorp/gcommon for protocol buffer definitions
 - **Generated Go Code**: Pre-generated Go bindings for all gcommon services
 - **Versioned Releases**: Follows semantic versioning for compatibility
-- **Module Support**: Proper Go module with github.com/jdfalk/gcommon path
+- **Module Support**: Proper Go module with github.com/falkcorp/gcommon path
 - **Documentation**: Comprehensive API documentation
 
 ## Installation
 
 ```bash
-go get github.com/jdfalk/gcommon
+go get github.com/falkcorp/gcommon
 ```
 
 ## Usage
@@ -30,9 +30,9 @@ go get github.com/jdfalk/gcommon
 
 ```go
 import (
-    "github.com/jdfalk/gcommon/common/v1"
-    "github.com/jdfalk/gcommon/health/v1"
-    "github.com/jdfalk/gcommon/metrics/v1"
+    "github.com/falkcorp/gcommon/common/v1"
+    "github.com/falkcorp/gcommon/health/v1"
+    "github.com/falkcorp/gcommon/metrics/v1"
     // ... other modules
 )
 ```
@@ -46,8 +46,8 @@ import (
     "context"
     "log"
 
-    commonv1 "github.com/jdfalk/gcommon/common/v1"
-    healthv1 "github.com/jdfalk/gcommon/health/v1"
+    commonv1 "github.com/falkcorp/gcommon/common/v1"
+    healthv1 "github.com/falkcorp/gcommon/health/v1"
 )
 
 func main() {
@@ -69,22 +69,22 @@ The Go SDK includes bindings for all 9 gcommon modules:
 
 | Module           | Package Path                                | Description                      |
 | ---------------- | ------------------------------------------- | -------------------------------- |
-| **common**       | `github.com/jdfalk/gcommon/common/v1`       | Shared types, errors, pagination |
-| **config**       | `github.com/jdfalk/gcommon/config/v1`       | Configuration management         |
-| **database**     | `github.com/jdfalk/gcommon/database/v1`     | Database operations              |
-| **health**       | `github.com/jdfalk/gcommon/health/v1`       | Health checks and monitoring     |
-| **media**        | `github.com/jdfalk/gcommon/media/v1`        | Media processing                 |
-| **metrics**      | `github.com/jdfalk/gcommon/metrics/v1`      | System metrics                   |
-| **organization** | `github.com/jdfalk/gcommon/organization/v1` | Organization management          |
-| **queue**        | `github.com/jdfalk/gcommon/queue/v1`        | Message queuing                  |
-| **web**          | `github.com/jdfalk/gcommon/web/v1`          | Web services                     |
+| **common**       | `github.com/falkcorp/gcommon/common/v1`       | Shared types, errors, pagination |
+| **config**       | `github.com/falkcorp/gcommon/config/v1`       | Configuration management         |
+| **database**     | `github.com/falkcorp/gcommon/database/v1`     | Database operations              |
+| **health**       | `github.com/falkcorp/gcommon/health/v1`       | Health checks and monitoring     |
+| **media**        | `github.com/falkcorp/gcommon/media/v1`        | Media processing                 |
+| **metrics**      | `github.com/falkcorp/gcommon/metrics/v1`      | System metrics                   |
+| **organization** | `github.com/falkcorp/gcommon/organization/v1` | Organization management          |
+| **queue**        | `github.com/falkcorp/gcommon/queue/v1`        | Message queuing                  |
+| **web**          | `github.com/falkcorp/gcommon/web/v1`          | Web services                     |
 
 ## Development
 
 ### Building from Source
 
 ```bash
-git clone https://github.com/jdfalk/gcommon-go.git
+git clone https://github.com/falkcorp/gcommon-go.git
 cd gcommon-go
 make build
 ```
@@ -99,8 +99,8 @@ buf generate
 
 ## Related Repositories
 
-- **[gcommon](https://github.com/jdfalk/gcommon)** - Protocol buffer definitions (BSR: buf.build/jdfalk/gcommon)
-- **[gcommon-py](https://github.com/jdfalk/gcommon-py)** - Python SDK
+- **[gcommon](https://github.com/falkcorp/gcommon)** - Protocol buffer definitions (BSR: buf.build/falkcorp/gcommon)
+- **[gcommon-py](https://github.com/falkcorp/gcommon-py)** - Python SDK
 
 ## Contributing
 

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -4,7 +4,7 @@
 
 version: v2
 inputs:
-  - module: buf.build/jdfalk/gcommon
+  - module: buf.build/falkcorp/gcommon
 managed:
   enabled: true
   disable:
@@ -15,87 +15,87 @@ managed:
     # BSR still has old structure (common/v1/) but we want new Go packages (pkg/commonpb)
     # v1 files: common/v1/ -> pkg/commonpb (no v1 subdirectory)
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: common/v1
-      value: github.com/jdfalk/gcommon/pkg/commonpb
+      value: github.com/falkcorp/gcommon/pkg/commonpb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: config/v1
-      value: github.com/jdfalk/gcommon/pkg/configpb
+      value: github.com/falkcorp/gcommon/pkg/configpb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: database/v1
-      value: github.com/jdfalk/gcommon/pkg/databasepb
+      value: github.com/falkcorp/gcommon/pkg/databasepb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: health/v1
-      value: github.com/jdfalk/gcommon/pkg/healthpb
+      value: github.com/falkcorp/gcommon/pkg/healthpb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: media/v1
-      value: github.com/jdfalk/gcommon/pkg/mediapb
+      value: github.com/falkcorp/gcommon/pkg/mediapb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: metrics/v1
-      value: github.com/jdfalk/gcommon/pkg/metricspb
+      value: github.com/falkcorp/gcommon/pkg/metricspb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: organization/v1
-      value: github.com/jdfalk/gcommon/pkg/organizationpb
+      value: github.com/falkcorp/gcommon/pkg/organizationpb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: queue/v1
-      value: github.com/jdfalk/gcommon/pkg/queuepb
+      value: github.com/falkcorp/gcommon/pkg/queuepb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: web/v1
-      value: github.com/jdfalk/gcommon/pkg/webpb
+      value: github.com/falkcorp/gcommon/pkg/webpb
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: auth/v1
-      value: github.com/jdfalk/gcommon/pkg/authpb
+      value: github.com/falkcorp/gcommon/pkg/authpb
 
     # v2 files: old BSR paths to new pb-suffixed Go packages with v2 subdirectory
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: common/v2
-      value: github.com/jdfalk/gcommon/pkg/commonpb/v2
+      value: github.com/falkcorp/gcommon/pkg/commonpb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: config/v2
-      value: github.com/jdfalk/gcommon/pkg/configpb/v2
+      value: github.com/falkcorp/gcommon/pkg/configpb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: database/v2
-      value: github.com/jdfalk/gcommon/pkg/databasepb/v2
+      value: github.com/falkcorp/gcommon/pkg/databasepb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: health/v2
-      value: github.com/jdfalk/gcommon/pkg/healthpb/v2
+      value: github.com/falkcorp/gcommon/pkg/healthpb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: media/v2
-      value: github.com/jdfalk/gcommon/pkg/mediapb/v2
+      value: github.com/falkcorp/gcommon/pkg/mediapb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: metrics/v2
-      value: github.com/jdfalk/gcommon/pkg/metricspb/v2
+      value: github.com/falkcorp/gcommon/pkg/metricspb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: organization/v2
-      value: github.com/jdfalk/gcommon/pkg/organizationpb/v2
+      value: github.com/falkcorp/gcommon/pkg/organizationpb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: queue/v2
-      value: github.com/jdfalk/gcommon/pkg/queuepb/v2
+      value: github.com/falkcorp/gcommon/pkg/queuepb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: web/v2
-      value: github.com/jdfalk/gcommon/pkg/webpb/v2
+      value: github.com/falkcorp/gcommon/pkg/webpb/v2
     - file_option: go_package_prefix
-      module: buf.build/jdfalk/gcommon
+      module: buf.build/falkcorp/gcommon
       path: auth/v2
-      value: github.com/jdfalk/gcommon/pkg/authpb/v2
+      value: github.com/falkcorp/gcommon/pkg/authpb/v2
 plugins:
   - local: protoc-gen-go
     out: pkg

--- a/buf.yaml
+++ b/buf.yaml
@@ -4,7 +4,7 @@
 
 version: v2
 deps:
-  - buf.build/jdfalk/gcommon
+  - buf.build/falkcorp/gcommon
   - buf.build/googleapis/googleapis
   - buf.build/bufbuild/protovalidate
   - buf.build/protocolbuffers/wellknowntypes

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,20 @@
-module github.com/jdfalk/gcommon
+module github.com/falkcorp/gcommon
 
 go 1.24.0
 
 // Replace directives for local sub-modules
-replace github.com/jdfalk/gcommon/internal => ./internal
+replace github.com/falkcorp/gcommon/internal => ./internal
 
-replace github.com/jdfalk/gcommon/services => ./services
+replace github.com/falkcorp/gcommon/services => ./services
 
-replace github.com/jdfalk/gcommon/services/health => ./services/health
+replace github.com/falkcorp/gcommon/services/health => ./services/health
 
-replace github.com/jdfalk/gcommon/services/auth => ./services/auth
+replace github.com/falkcorp/gcommon/services/auth => ./services/auth
 
-replace github.com/jdfalk/gcommon/pkg/authpb/v2 => ./pkg/authpb/v2
+replace github.com/falkcorp/gcommon/pkg/authpb/v2 => ./pkg/authpb/v2
 
 require (
-	github.com/jdfalk/gcommon/internal v0.0.0-20251003134307-5cabf522c911
+	github.com/falkcorp/gcommon/internal v0.0.0-20251003134307-5cabf522c911
 	google.golang.org/grpc v1.75.1
 )
 


### PR DESCRIPTION
## Migrate org references: jdfalk → falkcorp

Automated PR to update all workflow `uses:` references, Go module paths, and GHCR image tags
from `jdfalk/` to `falkcorp/` as part of the organization migration.

### Changed files:
- `buf.gen.yaml`
- `.github/workflows/ci.yml`
- `buf.yaml`
- `go.mod`
- `.github/workflows/sync-protos.yml`
- `README.md`

🤖 Generated by `scripts/org-migration/update-workflow-refs.py`