### PR TITLE
chore(standards): add .standards submodule and centralize AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,27 @@
+<!-- file: .github/copilot-instructions.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: a3f7e2d1-8b4c-4e6a-9f1d-2c5b3a7e8f0d -->
+<!-- last-edited: 2026-06-13 -->
+
+# gcommon — Additional Context
+
+Org-wide coding standards (file headers, language rules, commit format) are at
+**https://github.com/falkcarp/.github** and apply automatically to this repo.
+
+For full project context: **CLAUDE.md** at the repo root.
+
+## Project overview
+
+Go SDK for gcommon protocol buffers with shared utilities. Language: Go.
+
+## Key directories
+
+| Path | Purpose |
+|------|---------|
+| `buf.gen.yaml` | Buf code generation config |
+| `buf.yaml` | Buf module definition |
+
+## Critical constraints
+
+- Module path uses `buf.build/falkcorp/gcommon`
+- Use `git clone --recurse-submodules` to populate `.standards/`

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".standards"]
+	path = .standards
+	url = https://github.com/falkcorp/.github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,11 @@
 <!-- file: AGENTS.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 2.0.0 -->
 <!-- guid: 2e7c1a4b-5d3f-4b8c-9e1f-7a6b2c3d4e5f -->
+<!-- last-edited: 2026-06-13 -->
 
 # AGENTS.md
 
-> NOTE: This is a pointer. All detailed Copilot, agent, and workflow instructions are in the `.github/` directory.
+See **CLAUDE.md** for all agent instructions and project context.
 
-## Canonical Source for Agent Instructions
-
-- General rules: `.github/instructions/`
-- System documentation: `.github/copilot-instructions.md`
-
-> For any agent, Copilot, or workflow task, **always refer to the above files.**
+Org-wide coding standards (file headers, language rules, commit format):
+**https://github.com/falkcarp/.github**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+<!-- file: CLAUDE.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b5d8f3a2-7c1e-4d9b-8a2f-3e6c1b4d7f2a -->
+<!-- last-edited: 2026-06-13 -->
+
+# gcommon
+
+Go SDK for gcommon protocol buffers with shared utilities.
+
+## Coding Standards
+
+Org-wide coding standards are in the `.standards/` git submodule (cloned from `https://github.com/falkcarp/.github`).
+Always clone with `git clone --recurse-submodules` so these are available.
+
+Key files:
+- **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
+- **Commit format:** `.standards/instructions/commit-messages.md`


### PR DESCRIPTION
## Summary

- Adds `.standards/` git submodule → `falkcarp/.github` (org-wide coding standards)
- Slims `.github/copilot-instructions.md` to repo-specific stub only (removes template boilerplate)
- Creates/updates `CLAUDE.md` to reference `.standards/instructions/` for coding standards
- Updates `AGENTS.md` to redirect to `CLAUDE.md`

After merging: `git clone --recurse-submodules` auto-populates `.standards/` with coding standards.

## Test plan
- [ ] `.gitmodules` contains `.standards` → `https://github.com/falkcarp/.github`
- [ ] `copilot-instructions.md` is ≤25 lines and references CLAUDE.md
- [ ] `CLAUDE.md` has `## Coding Standards` section referencing `.standards/`