### PR TITLE
ci: add submodules: recursive to all checkout steps

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout gcommon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 


### PR DESCRIPTION
Ensures the .standards/ submodule (falkcorp/.github) is populated in every CI run so agents and linters have org-wide coding standards available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)